### PR TITLE
Optimize `AbsoluteInt`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,5 +10,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.42
+          version: v1.43
           args: -c .golangci.yml -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - wsl
     - exhaustivestruct
     - paralleltest
+    - varnamelen
 linters-settings:
   govet:
     enable-all: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* optimize `AbsoluteInt` (with Two's complement implementation)
+
 ## v0.3.0
 
 * simplify `ReverseStrings` to reverse original slice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
 * optimize `AbsoluteInt` (with Two's complement implementation)
+* panic if call `AbsoluteInt` with the minimum value of integers (the absolute of the minimum value of integers is impossible to return)
 
 ## v0.3.0
 

--- a/basicalter/number.go
+++ b/basicalter/number.go
@@ -1,10 +1,12 @@
 package basicalter
 
+import (
+	"math/bits"
+)
+
 // AbsoluteInt return absolute value of integer.
 func AbsoluteInt(num int) int {
-	if num < 0 {
-		return -num
-	}
+	y := num >> (bits.UintSize - 1)
 
-	return num
+	return (num ^ y) - y
 }

--- a/basicalter/number.go
+++ b/basicalter/number.go
@@ -5,7 +5,14 @@ import (
 )
 
 // AbsoluteInt return absolute value of integer.
+//
+// If the 'num' is the minimum value of integers, the function panic
+// due to the lack of a corresponding positive value with integer type.
 func AbsoluteInt(num int) int {
+	if num == -1<<(bits.UintSize-1) {
+		panic("the absolute of the minimum value of integers is impossible (overflows int)")
+	}
+
 	y := num >> (bits.UintSize - 1)
 
 	return (num ^ y) - y

--- a/basicalter/number_test.go
+++ b/basicalter/number_test.go
@@ -1,9 +1,15 @@
 package basicalter_test
 
 import (
+	"math/bits"
 	"testing"
 
 	"github.com/jeremmfr/go-utils/basicalter"
+)
+
+const (
+	maxInt = 1<<(bits.UintSize-1) - 1
+	minInt = -1 << (bits.UintSize - 1)
 )
 
 func TestAbsolutInt(t *testing.T) {
@@ -15,4 +21,15 @@ func TestAbsolutInt(t *testing.T) {
 	if v := basicalter.AbsoluteInt(basicalter.AbsoluteInt(i)); v < 0 {
 		t.Errorf("AbsoluteInt(AbsoluteInt(%d)) return negative integer: %d", i, v)
 	}
+
+	i = minInt + 1
+	if v := basicalter.AbsoluteInt(i); v != maxInt {
+		t.Errorf("AbsoluteInt(%d) not return expected integer %d, found %d", i, maxInt, v)
+	}
+}
+
+func TestAbsolutIntPanic(t *testing.T) {
+	defer func() { _ = recover() }()
+	basicalter.AbsoluteInt(minInt)
+	t.Errorf("AbsoluteInt doesn't panic with the minimum value of integers")
 }

--- a/basicalter/number_test.go
+++ b/basicalter/number_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/jeremmfr/go-utils/basicalter"
 )
 
-func TestAbsolutint(t *testing.T) {
+func TestAbsolutInt(t *testing.T) {
 	i := -2
 
-	if basicalter.AbsoluteInt(i) < 0 {
-		t.Errorf("AbsoluteInt return negative integer")
+	if v := basicalter.AbsoluteInt(i); v < 0 {
+		t.Errorf("AbsoluteInt(%d) return negative integer: %d", i, v)
 	}
-	if basicalter.AbsoluteInt(basicalter.AbsoluteInt(i)) < 0 {
-		t.Errorf("AbsoluteInt return negative integer")
+	if v := basicalter.AbsoluteInt(basicalter.AbsoluteInt(i)); v < 0 {
+		t.Errorf("AbsoluteInt(AbsoluteInt(%d)) return negative integer: %d", i, v)
 	}
 }


### PR DESCRIPTION
* optimize `AbsoluteInt` (with Two's complement implementation)
* panic if call `AbsoluteInt` with the minimum value of integers (the absolute of the minimum value of integers is impossible to return)