### PR TITLE
Workflows go 1.18 lint 1.45

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "workflows:"
+    schedule:
+      interval: daily
+    assignees:
+      - "jeremmfr"
+    reviewers:
+      - "jeremmfr"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Test
+        run: go test -v ./...
+
+  test-1_18:
+    name: Test 1.18
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.18
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Test
         run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic 
 
       - name: Codecov

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,5 +10,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.45
           args: -c .golangci.yml -v


### PR DESCRIPTION
- workflows: add test with golang v1.18
- workflows: bump golangci-lint to v1.45
- add dependabot