### PR TITLE
basiccheck: add functions with generic parameters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,34 +1,6 @@
 name: Go Tests
 on: [push, pull_request]
 jobs:
-  test-1_16:
-    name: Test 1.16
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.16
-        id: go
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Test
-        run: go test -v ./...
-
-  test-1_17:
-    name: Test 1.17
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-        id: go
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Test
-        run: go test -v ./...
-
   test-1_18:
     name: Test 1.18
     runs-on: ubuntu-latest
@@ -37,6 +9,20 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: 1.18
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Test
+        run: go test -v ./...
+
+  test-1_19:
+    name: Test 1.19
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.19
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,5 +10,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45
+          version: v1.50
           args: -c .golangci.yml -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,6 +5,11 @@ jobs:
     name: Run
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+        id: go
       - name: Check out code
         uses: actions/checkout@v3
       - name: golangci-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - exhaustivestruct
     - paralleltest
     - varnamelen
+    - dupl
 linters-settings:
   govet:
     enable-all: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add function `OneOfSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
 * add function `InSlice` with generic parameters in package `basiccheck` to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
 * add function `EqualSlice` with generic parameters in package `basiccheck` to replace `EqualStringSlice` function which is now deprecated
+* add function `AllInSliceWith` with generic parameters in package `basiccheck` to replace `AllStringsWith` function which is now deprecated
 
 ## v0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * golang 1.18 is now the minimum version
 * add function `OneOfSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
+* add function `InSlice` with generic parameters in package `basiccheck` to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
 
 ## v0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * golang 1.18 is now the minimum version
 * add function `OneOfSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
 * add function `InSlice` with generic parameters in package `basiccheck` to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
+* add function `EqualSlice` with generic parameters in package `basiccheck` to replace `EqualStringSlice` function which is now deprecated
 
 ## v0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # changelog
 
 * golang 1.18 is now the minimum version
-* add function `OneOfSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
+* add function `OneInSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
 * add function `InSlice` with generic parameters in package `basiccheck` to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
 * add function `EqualSlice` with generic parameters in package `basiccheck` to replace `EqualStringSlice` function which is now deprecated
 * add function `AllInSliceWith` with generic parameters in package `basiccheck` to replace `AllStringsWith` function which is now deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # changelog
 
+* golang 1.18 is now the minimum version
+* add function `OneOfSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
+
 ## v0.4.1
 
 * optimize `UniqueStrings` (reduce memory usage)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # changelog
 
 * golang 1.18 is now the minimum version
-* add function `OneInSliceWith` with generic parameters in package `basiccheck` to replace `OneOfStringsWith` function which is now deprecated
-* add function `InSlice` with generic parameters in package `basiccheck` to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
-* add function `EqualSlice` with generic parameters in package `basiccheck` to replace `EqualStringSlice` function which is now deprecated
-* add function `AllInSliceWith` with generic parameters in package `basiccheck` to replace `AllStringsWith` function which is now deprecated
+* add `OneInSliceWith` function with generic parameters in `basiccheck` package to replace `OneOfStringsWith` function which is now deprecated
+* add `InSlice` function with generic parameters in `basiccheck` package to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
+* add `EqualSlice` function with generic parameters in `basiccheck` package to replace `EqualStringSlice` function which is now deprecated
+* add `AllInSliceWith` function with generic parameters in `basiccheck` package to replace `AllStringsWith` function which is now deprecated
 
 ## v0.4.1
 
@@ -12,8 +12,8 @@
 
 ## v0.4.0
 
-* add functions `OneOfStringsWith` and `AllStringsWith` in package `basiccheck`
-* add functions `FilterStringsWith` and `ReplaceStringsWith` in package `basicalter`
+* add `OneOfStringsWith` and `AllStringsWith` functions in `basiccheck` package
+* add `FilterStringsWith` and `ReplaceStringsWith` functions in `basicalter` package
 
 ## v0.3.1
 

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -29,7 +29,7 @@ func TestDelEmptyStrings(t *testing.T) {
 
 	if v := basicalter.DelEmptyStrings(sliceOfString); len(v) != 2 {
 		t.Errorf("DelEmptyStrings didn't remove empty string: %v", v)
-	} else if !basiccheck.EqualStringSlice(v, []string{"foo", "bar"}) {
+	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
 		t.Errorf("DelEmptyStrings didn't remove empty string: %v", v)
 	}
 }
@@ -39,7 +39,7 @@ func TestDelStringInSlice(t *testing.T) {
 
 	if v := basicalter.DelStringInSlice("baz", sliceOfString); len(v) != 2 {
 		t.Errorf("DelStringInSlice didn't remove 'baz': %v", v)
-	} else if !basiccheck.EqualStringSlice(v, []string{"foo", "bar"}) {
+	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
 		t.Errorf("DelStringInSlice didn't remove 'baz': %v", v)
 	}
 }
@@ -51,7 +51,7 @@ func TestFilterStringsWith(t *testing.T) {
 		return strings.HasPrefix(s, "ba")
 	}); len(v) != 3 {
 		t.Errorf("FilterStringsWith didn't remove foo (without prefix 'ba'): %v", v)
-	} else if !basiccheck.EqualStringSlice(v, []string{"baz", "bar", "baz"}) {
+	} else if !basiccheck.EqualSlice(v, []string{"baz", "bar", "baz"}) {
 		t.Errorf("FilterStringsWith didn't remove foo (without prefix 'ba'): %v", v)
 	}
 }
@@ -62,7 +62,7 @@ func TestReverseSlice(t *testing.T) {
 	basicalter.ReverseStrings(sliceOfString)
 
 	desiredSlice := []string{"Hello", "World", "bar", "baz", "foo"}
-	if !basiccheck.EqualStringSlice(sliceOfString, desiredSlice) {
+	if !basiccheck.EqualSlice(sliceOfString, desiredSlice) {
 		t.Errorf("ReverseStrings didn't reverse slice: %v expected %v", sliceOfString, desiredSlice)
 	}
 }
@@ -73,7 +73,7 @@ func TestSortStringsByLengthInc(t *testing.T) {
 	basicalter.SortStringsByLengthInc(s)
 
 	desiredSlice := []string{"Go", "Grin", "Alpha", "Bravo", "Delta", "Gopher"}
-	if !basiccheck.EqualStringSlice(s, desiredSlice) {
+	if !basiccheck.EqualSlice(s, desiredSlice) {
 		t.Errorf("SortStringsByLength didn't sort slice with smaller first and lexicographic order")
 	}
 }
@@ -84,7 +84,7 @@ func TestSortStringsByLengthDec(t *testing.T) {
 	basicalter.SortStringsByLengthDec(s)
 
 	desiredSlice := []string{"Gopher", "Alpha", "Bravo", "Delta", "Grin", "Go"}
-	if !basiccheck.EqualStringSlice(s, desiredSlice) {
+	if !basiccheck.EqualSlice(s, desiredSlice) {
 		t.Errorf("SortStringsByLength didn't sort slice with smaller last and lexicographic order")
 	}
 }
@@ -94,7 +94,7 @@ func TestReplaceStringsWith(t *testing.T) {
 
 	basicalter.ReplaceStringsWith(sliceOfString, strings.ToLower)
 
-	if !basiccheck.EqualStringSlice(sliceOfString, []string{"foo", "bar", "baz"}) {
+	if !basiccheck.EqualSlice(sliceOfString, []string{"foo", "bar", "baz"}) {
 		t.Errorf("ReplaceStringsWith didn't replace all strings in slice "+
 			"with the lowercase version: %v", sliceOfString)
 	}

--- a/basiccheck/example_test.go
+++ b/basiccheck/example_test.go
@@ -9,7 +9,7 @@ import (
 func Example() {
 	sliceOfString := []string{"foo", "bar"}
 
-	if basiccheck.StringInSlice("bar", sliceOfString) {
+	if basiccheck.InSlice("bar", sliceOfString) {
 		fmt.Printf("bar found in %v", sliceOfString)
 		// Output: bar found in [foo bar]
 	} else {

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -1,5 +1,17 @@
 package basiccheck
 
+// OneOfSliceWith check if at least one element in a slice
+// returns true with the function 'find' passed in arguments.
+func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
+	for _, v := range list {
+		if find(v) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // StringInSlice check if a string is present in a slice of string.
 func StringInSlice(str string, list []string) bool {
 	return OneOfStringsWith(list, func(s string) bool {
@@ -45,6 +57,8 @@ func Int64InSlice(num int64, list []int64) bool {
 
 // OneOfStringsWith check if at least one string in a slice
 // returns true with the function 'find' passed in arguments.
+//
+// Deprecated: use OneOfSliceWith() instead.
 func OneOfStringsWith(list []string, find func(string) bool) bool {
 	for _, v := range list {
 		if find(v) {

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -7,6 +7,20 @@ func InSlice[T comparable](elm T, list []T) bool {
 	})
 }
 
+// EqualSlice check if two slice is Equal: same length, same element in same order.
+func EqualSlice[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // OneOfSliceWith check if at least one element in a slice
 // returns true with the function 'find' passed in arguments.
 func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
@@ -28,7 +42,10 @@ func StringInSlice(str string, list []string) bool {
 	})
 }
 
-// EqualStringSlice check if two slice of string is Equal: same length, same element in same order.
+// EqualStringSlice check if two slice of string is Equal:
+// same length, same element in same order.
+//
+// Deprecated: use EqualSlice() instead.
 func EqualStringSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -2,7 +2,7 @@ package basiccheck
 
 // InSlice check if element is present in a slice.
 func InSlice[T comparable](elm T, list []T) bool {
-	return OneOfSliceWith(list, func(v T) bool {
+	return OneInSliceWith(list, func(v T) bool {
 		return v == elm
 	})
 }
@@ -21,9 +21,9 @@ func EqualSlice[T comparable](a, b []T) bool {
 	return true
 }
 
-// OneOfSliceWith check if at least one element in a slice
+// OneInSliceWith check if at least one element in a slice
 // returns true with the function 'find' passed in arguments.
-func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
+func OneInSliceWith[T any](list []T, find func(T) bool) bool {
 	for _, v := range list {
 		if find(v) {
 			return true
@@ -100,7 +100,7 @@ func Int64InSlice(num int64, list []int64) bool {
 // OneOfStringsWith check if at least one string in a slice
 // returns true with the function 'find' passed in arguments.
 //
-// Deprecated: use OneOfSliceWith() instead.
+// Deprecated: use OneInSliceWith() instead.
 func OneOfStringsWith(list []string, find func(string) bool) bool {
 	for _, v := range list {
 		if find(v) {

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -33,6 +33,18 @@ func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
 	return false
 }
 
+// AllInSliceWith check if all elements in a slice
+// return true with the function 'valid' passed in arguments.
+func AllInSliceWith[T any](list []T, valid func(T) bool) bool {
+	for _, v := range list {
+		if !valid(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // StringInSlice check if a string is present in a slice of string.
 //
 // Deprecated: use InSlice() instead.
@@ -101,6 +113,8 @@ func OneOfStringsWith(list []string, find func(string) bool) bool {
 
 // AllStringsWith check if all strings in a slice
 // return true with the function 'valid' passed in arguments.
+//
+// Deprecated: use AllInSliceWith() instead.
 func AllStringsWith(list []string, valid func(string) bool) bool {
 	for _, v := range list {
 		if !valid(v) {

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -1,5 +1,12 @@
 package basiccheck
 
+// InSlice check if element is present in a slice.
+func InSlice[T comparable](elm T, list []T) bool {
+	return OneOfSliceWith(list, func(v T) bool {
+		return v == elm
+	})
+}
+
 // OneOfSliceWith check if at least one element in a slice
 // returns true with the function 'find' passed in arguments.
 func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
@@ -13,6 +20,8 @@ func OneOfSliceWith[T any](list []T, find func(T) bool) bool {
 }
 
 // StringInSlice check if a string is present in a slice of string.
+//
+// Deprecated: use InSlice() instead.
 func StringInSlice(str string, list []string) bool {
 	return OneOfStringsWith(list, func(s string) bool {
 		return s == str
@@ -34,6 +43,8 @@ func EqualStringSlice(a, b []string) bool {
 }
 
 // IntInSlice check if int is present in slice of int.
+//
+// Deprecated: use InSlice() instead.
 func IntInSlice(num int, list []int) bool {
 	for _, v := range list {
 		if v == num {
@@ -45,6 +56,8 @@ func IntInSlice(num int, list []int) bool {
 }
 
 // Int64InSlice check if int64 is present in slice of int64.
+//
+// Deprecated: use InSlice() instead.
 func Int64InSlice(num int64, list []int64) bool {
 	for _, v := range list {
 		if v == num {

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -25,6 +25,24 @@ func TestInSlice(t *testing.T) {
 	}
 }
 
+func TestEqualSlice(t *testing.T) {
+	sliceA := []string{"foo", "bar", "baz"}
+	sliceB := []string{"foo", "baz", "bar"}
+	sliceC := []string{"foo", "bar"}
+
+	if basiccheck.EqualSlice(sliceA, sliceB) {
+		t.Errorf("EqualSlice found equal slice %v, %v", sliceA, sliceB)
+	}
+	if basiccheck.EqualSlice(sliceA, sliceC) {
+		t.Errorf("EqualSlice found equal slice %v, %v", sliceA, sliceC)
+	}
+
+	sliceC = append(sliceC, "baz")
+	if !basiccheck.EqualSlice(sliceA, sliceC) {
+		t.Errorf("EqualSlice didn't find equal slice %v, %v", sliceA, sliceC)
+	}
+}
+
 func TestOneOfSliceWith(t *testing.T) {
 	sliceOfString := []string{}
 

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -7,6 +7,30 @@ import (
 	"github.com/jeremmfr/go-utils/basiccheck"
 )
 
+func TestOneOfSliceWith(t *testing.T) {
+	sliceOfString := []string{}
+
+	if basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+		return strings.HasPrefix(s, "b")
+	}) {
+		t.Errorf("OneOfSliceWith found prefix 'b' in empty slice")
+	}
+
+	sliceOfString = append(sliceOfString, []string{"foo", "baz", "bar"}...)
+	if !basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+		return strings.HasPrefix(s, "b")
+	}) {
+		t.Errorf("OneOfSliceWith didn't find prefix 'b' in one of %v", sliceOfString)
+	}
+
+	// find a string without all lowercase letters
+	if basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+		return strings.ToLower(s) != s
+	}) {
+		t.Errorf("OneOfSliceWith found a capital letter in one of %v", sliceOfString)
+	}
+}
+
 func TestStringInSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "bar"}
 

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -67,6 +67,39 @@ func TestOneOfSliceWith(t *testing.T) {
 	}
 }
 
+func TestAllInSliceWith(t *testing.T) {
+	sliceOfString := []string{}
+
+	if !basiccheck.AllInSliceWith(sliceOfString, func(s string) bool {
+		return strings.HasPrefix(s, "b")
+	}) {
+		t.Errorf("AllInSliceWith found prefix 'b' in empty slice")
+	}
+
+	sliceOfString = append(sliceOfString, []string{"baz", "bar"}...)
+	// check if all elements contains 'a'
+	if !basiccheck.AllInSliceWith(sliceOfString, func(s string) bool {
+		return strings.Contains(s, "a")
+	}) {
+		t.Errorf("AllInSliceWith found one of %v without 'a'", sliceOfString)
+	}
+
+	sliceOfString = append(sliceOfString, "foo")
+	// check if all elements contains 'a'
+	if basiccheck.AllInSliceWith(sliceOfString, func(s string) bool {
+		return strings.Contains(s, "a")
+	}) {
+		t.Errorf("AllInSliceWith didn't find 'foo' (without 'a') in %v", sliceOfString)
+	}
+
+	// check if all elements have lowercase letters
+	if !basiccheck.AllInSliceWith(sliceOfString, func(s string) bool {
+		return strings.ToLower(s) == s
+	}) {
+		t.Errorf("AllInSliceWith found a capital letter in one of %v", sliceOfString)
+	}
+}
+
 func TestStringInSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "bar"}
 

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -43,27 +43,27 @@ func TestEqualSlice(t *testing.T) {
 	}
 }
 
-func TestOneOfSliceWith(t *testing.T) {
+func TestOneInSliceWith(t *testing.T) {
 	sliceOfString := []string{}
 
-	if basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+	if basiccheck.OneInSliceWith(sliceOfString, func(s string) bool {
 		return strings.HasPrefix(s, "b")
 	}) {
-		t.Errorf("OneOfSliceWith found prefix 'b' in empty slice")
+		t.Errorf("OneInSliceWith found prefix 'b' in empty slice")
 	}
 
 	sliceOfString = append(sliceOfString, []string{"foo", "baz", "bar"}...)
-	if !basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+	if !basiccheck.OneInSliceWith(sliceOfString, func(s string) bool {
 		return strings.HasPrefix(s, "b")
 	}) {
-		t.Errorf("OneOfSliceWith didn't find prefix 'b' in one of %v", sliceOfString)
+		t.Errorf("OneInSliceWith didn't find prefix 'b' in one of %v", sliceOfString)
 	}
 
 	// find a string without all lowercase letters
-	if basiccheck.OneOfSliceWith(sliceOfString, func(s string) bool {
+	if basiccheck.OneInSliceWith(sliceOfString, func(s string) bool {
 		return strings.ToLower(s) != s
 	}) {
-		t.Errorf("OneOfSliceWith found a capital letter in one of %v", sliceOfString)
+		t.Errorf("OneInSliceWith found a capital letter in one of %v", sliceOfString)
 	}
 }
 

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/jeremmfr/go-utils/basiccheck"
 )
 
+func TestInSlice(t *testing.T) {
+	sliceOfString := []string{"foo", "bar"}
+	if !basiccheck.InSlice("bar", sliceOfString) {
+		t.Errorf("InSlice didn't find bar in %v", sliceOfString)
+	}
+	if basiccheck.InSlice("baz", sliceOfString) {
+		t.Errorf("InSlice found baz in %v", sliceOfString)
+	}
+
+	sliceOfInt := []int{2, 4, 10}
+	if !basiccheck.InSlice(4, sliceOfInt) {
+		t.Errorf("InSlice didn't find 4 in %v", sliceOfInt)
+	}
+	if basiccheck.InSlice(6, sliceOfInt) {
+		t.Errorf("InSlice found 6 in %v", sliceOfInt)
+	}
+}
+
 func TestOneOfSliceWith(t *testing.T) {
 	sliceOfString := []string{}
 
@@ -35,10 +53,10 @@ func TestStringInSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "bar"}
 
 	if !basiccheck.StringInSlice("bar", sliceOfString) {
-		t.Errorf("CheckIfStringInSlice didn't find bar in %v", sliceOfString)
+		t.Errorf("StringInSlice didn't find bar in %v", sliceOfString)
 	}
 	if basiccheck.StringInSlice("baz", sliceOfString) {
-		t.Errorf("CheckIfStringInSlice found baz in %v", sliceOfString)
+		t.Errorf("StringInSlice found baz in %v", sliceOfString)
 	}
 }
 

--- a/basiccheck/string.go
+++ b/basiccheck/string.go
@@ -6,11 +6,7 @@ import (
 
 // StringHasOneOfPrefixes check if string has one of prefix list.
 func StringHasOneOfPrefixes(s string, list []string) bool {
-	for _, item := range list {
-		if strings.HasPrefix(s, item) {
-			return true
-		}
-	}
-
-	return false
+	return OneOfSliceWith(list, func(v string) bool {
+		return strings.HasPrefix(s, v)
+	})
 }

--- a/basiccheck/string.go
+++ b/basiccheck/string.go
@@ -6,7 +6,7 @@ import (
 
 // StringHasOneOfPrefixes check if string has one of prefix list.
 func StringHasOneOfPrefixes(s string, list []string) bool {
-	return OneOfSliceWith(list, func(v string) bool {
+	return OneInSliceWith(list, func(v string) bool {
 		return strings.HasPrefix(s, v)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jeremmfr/go-utils
 
-go 1.16
+go 1.18


### PR DESCRIPTION
* golang 1.18 is now the minimum version
* add `OneInSliceWith` function with generic parameters in `basiccheck` package to replace `OneOfStringsWith` function which is now deprecated
* add `InSlice` function with generic parameters in `basiccheck` package to replace `StringInSlice`, `IntInSlice`, `Int64InSlice` functions which are now deprecated
* add `EqualSlice` function with generic parameters in `basiccheck` package to replace `EqualStringSlice` function which is now deprecated
* add `AllInSliceWith` function with generic parameters in `basiccheck` package to replace `AllStringsWith` function which is now deprecated