### PR TITLE
Alter with generics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Test
-        run: go test -v ./... -coverprofile=coverage.txt -covermode=atomic 
+        run: go test -v ./... -coverprofile=coverage.out -covermode=atomic 
 
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.txt
+          file: ./coverage.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - paralleltest
     - varnamelen
     - dupl
+    - ireturn
 linters-settings:
   govet:
     enable-all: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
 * add `DelInSlice` function with generic parameters in `basicalter` package to replace `DelStringInSlice` function which is now deprecated
 * add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated
+* add `ReverseSlice` function with generic parameters in `basicalter` package to replace `ReverseStrings` function which is now deprecated
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add `DelInSlice` function with generic parameters in `basicalter` package to replace `DelStringInSlice` function which is now deprecated
 * add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated
 * add `ReverseSlice` function with generic parameters in `basicalter` package to replace `ReverseStrings` function which is now deprecated
+* add `ReplaceInSliceWith` function with generic parameters in `basicalter` package to replace `ReplaceStringsWith` function which is now deprecated
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
 * add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
+* add `DelInSlice` function with generic parameters in `basicalter` package to replace `DelStringInSlice` function which is now deprecated
 * add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated
 
 ## v0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
+
 ## v0.5.0
 
 * golang 1.18 is now the minimum version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
 * add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
+* add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated
 
 ## v0.5.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+default: gotest/html
+
+.PHONY: gotest gotest/html
+
+gotest:
+	go test -covermode=count -v ./...
+
+gotest/html:
+	go test -v ./... -coverprofile=coverage.out && go tool cover -html=coverage.out

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -14,6 +14,13 @@ func Example() {
 	// Output: [foo bar]
 }
 
+func ExampleAbsoluteInt() {
+	input := -10
+	output := basicalter.AbsoluteInt(input)
+	fmt.Printf("%d", output)
+	// Output: 10
+}
+
 func ExampleUniqueInSlice() {
 	input := []string{"foo", "bar", "foo"}
 	output := basicalter.UniqueInSlice(input)
@@ -42,6 +49,20 @@ func ExampleReverseSlice() {
 	basicalter.ReverseSlice(input)
 	fmt.Printf("%v", input)
 	// Output: [bar baz foo]
+}
+
+func ExampleSortStringsByLengthInc() {
+	input := []string{"a1", "a10", "a11", "a100", "a2", "a3"}
+	basicalter.SortStringsByLengthInc(input)
+	fmt.Printf("%v", input)
+	// Output: [a1 a2 a3 a10 a11 a100]
+}
+
+func ExampleSortStringsByLengthDec() {
+	input := []string{"a1", "a10", "a11", "a100", "a2", "a3"}
+	basicalter.SortStringsByLengthDec(input)
+	fmt.Printf("%v", input)
+	// Output: [a100 a10 a11 a1 a2 a3]
 }
 
 func ExampleReplaceInSliceWith() {

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -36,3 +36,10 @@ func ExampleFilterInSliceWith() {
 	fmt.Printf("%v", output)
 	// Output: [baz bar baz]
 }
+
+func ExampleReverseSlice() {
+	input := []string{"foo", "baz", "bar"}
+	basicalter.ReverseSlice(input)
+	fmt.Printf("%v", input)
+	// Output: [bar baz foo]
+}

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -2,6 +2,7 @@ package basicalter_test
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jeremmfr/go-utils/basicalter"
 )
@@ -18,4 +19,13 @@ func ExampleUniqueInSlice() {
 	output := basicalter.UniqueInSlice(input)
 	fmt.Printf("%v", output)
 	// Output: [foo bar]
+}
+
+func ExampleFilterInSliceWith() {
+	input := []string{"foo", "baz", "bar", "baz"}
+	output := basicalter.FilterInSliceWith(input, func(s string) bool {
+		return strings.HasPrefix(s, "ba")
+	})
+	fmt.Printf("%v", output)
+	// Output: [baz bar baz]
 }

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -7,8 +7,15 @@ import (
 )
 
 func Example() {
-	sliceOfString := []string{"foo", "bar", "foo"}
+	input := []string{"foo", "bar", "foo"}
+	output := basicalter.UniqueInSlice(input)
+	fmt.Printf("%v", output)
+	// Output: [foo bar]
+}
 
-	fmt.Printf("%v", basicalter.UniqueStrings(sliceOfString))
+func ExampleUniqueInSlice() {
+	input := []string{"foo", "bar", "foo"}
+	output := basicalter.UniqueInSlice(input)
+	fmt.Printf("%v", output)
 	// Output: [foo bar]
 }

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -43,3 +43,10 @@ func ExampleReverseSlice() {
 	fmt.Printf("%v", input)
 	// Output: [bar baz foo]
 }
+
+func ExampleReplaceInSliceWith() {
+	input := []string{"Foo", "Bar", "Baz"}
+	basicalter.ReplaceInSliceWith(input, strings.ToLower)
+	fmt.Printf("%v", input)
+	// Output: [foo bar baz]
+}

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -21,6 +21,13 @@ func ExampleUniqueInSlice() {
 	// Output: [foo bar]
 }
 
+func ExampleDelInSlice() {
+	input := []string{"foo", "baz", "bar"}
+	output := basicalter.DelInSlice("baz", input)
+	fmt.Printf("%v", output)
+	// Output: [foo bar]
+}
+
 func ExampleFilterInSliceWith() {
 	input := []string{"foo", "baz", "bar", "baz"}
 	output := basicalter.FilterInSliceWith(input, func(s string) bool {

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -46,12 +46,23 @@ func UniqueStrings(list []string) []string {
 	return r
 }
 
-// DelEmptyStrings remove empty elements in slice of string.
+// DelEmptyStrings remove empty elements in slice of string
+// and return the result with a new slice.
 func DelEmptyStrings(list []string) []string {
-	return DelStringInSlice("", list)
+	return DelInSlice("", list)
+}
+
+// DelInSlice remove all occurrence of an element in a slice
+// and return the result with a new slice.
+func DelInSlice[T comparable, S ~[]T](elem T, list S) S {
+	return FilterInSliceWith(list, func(e T) bool {
+		return e != elem
+	})
 }
 
 // DelStringInSlice remove all occurrence of a string in slice of string.
+//
+// Deprecated: use DelInSlice() instead.
 func DelStringInSlice(str string, list []string) []string {
 	return FilterStringsWith(list, func(s string) bool {
 		return s != str

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -169,8 +169,18 @@ func (s sortStringsLengthDec) Less(i, j int) bool {
 	return s[i] < s[j]
 }
 
+// ReplaceInSliceWith replace each element of a slice
+// with the result of the function 'replace' passed in arguments.
+func ReplaceInSliceWith[T any](list []T, replace func(T) T) {
+	for i := 0; i < len(list); i++ {
+		list[i] = replace(list[i])
+	}
+}
+
 // ReplaceStringsWith replace each string of a slice
 // with the result of the function 'replace' passed in arguments.
+//
+// Deprecated: use ReplaceInSliceWith() instead.
 func ReplaceStringsWith(list []string, replace func(string) string) {
 	for i := 0; i < len(list); i++ {
 		list[i] = replace(list[i])

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -58,8 +58,27 @@ func DelStringInSlice(str string, list []string) []string {
 	})
 }
 
+// FilterInSliceWith generate a new slice
+// by applying on an input slice 'list' a function 'filter'
+// to determine the inclusion of each element.
+func FilterInSliceWith[T any, S ~[]T](list S, filter func(T) bool) S {
+	if list == nil {
+		return nil
+	}
+	r := make(S, 0, cap(list))
+	for _, v := range list {
+		if filter(v) {
+			r = append(r, v)
+		}
+	}
+
+	return r
+}
+
 // FilterStringsWith generate a new slice of string
 // by applying on 'list' a function 'filter' to determine the inclusion of each element.
+//
+// Deprecated: use FilterInSliceWith() instead.
 func FilterStringsWith(list []string, filter func(string) bool) []string {
 	r := make([]string, 0)
 	for _, v := range list {

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -101,7 +101,16 @@ func FilterStringsWith(list []string, filter func(string) bool) []string {
 	return r
 }
 
+// ReverseSlice reverse order of a slice last to first, before last to second, etc.
+func ReverseSlice[T any](list []T) {
+	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
+		list[i], list[j] = list[j], list[i]
+	}
+}
+
 // ReverseStrings reverse order of string slice last to first, before last to second, etc.
+//
+// Deprecated: use ReverseSlice() instead.
 func ReverseStrings(list []string) {
 	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
 		list[i], list[j] = list[j], list[i]

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -2,7 +2,37 @@ package basicalter
 
 import "sort"
 
+// UniqueInSlice remove duplicate elements in slice
+// and return the result with a new slice.
+func UniqueInSlice[T comparable, S ~[]T](list S) S {
+	switch {
+	case list == nil:
+		return nil
+	case len(list) == 0:
+		return make(S, 0, cap(list))
+	case len(list) == 1:
+		r := make(S, 1, cap(list))
+		r[0] = list[0]
+
+		return r
+	default:
+		k := make(map[T]struct{}, len(list))
+		r := make(S, 0, cap(list))
+
+		for _, v := range list {
+			if _, ok := k[v]; !ok {
+				k[v] = struct{}{}
+				r = append(r, v)
+			}
+		}
+
+		return r
+	}
+}
+
 // UniqueStrings remove duplicate string in slice of string.
+//
+// Deprecated: use UniqueInSlice() instead.
 func UniqueStrings(list []string) []string {
 	k := make(map[string]struct{}, len(list))
 	r := []string{}

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -70,6 +70,16 @@ func TestDelEmptyStrings(t *testing.T) {
 	}
 }
 
+func TestDelInSlice(t *testing.T) {
+	sliceOfString := []string{"foo", "baz", "bar", "baz"}
+
+	if v := basicalter.DelInSlice("baz", sliceOfString); len(v) != 2 {
+		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
+	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
+		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
+	}
+}
+
 func TestDelStringInSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "baz", "bar", "baz"}
 

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -174,6 +174,20 @@ func TestSortStringsByLengthDec(t *testing.T) {
 	}
 }
 
+func TestReplaceInSliceWith(t *testing.T) {
+	sliceOfString := []string{"Foo", "Bar", "Baz"}
+
+	basicalter.ReplaceInSliceWith(sliceOfString, strings.ToLower)
+
+	if !basiccheck.EqualSlice(sliceOfString, []string{"foo", "bar", "baz"}) {
+		t.Errorf("ReplaceInSliceWith didn't replace all strings in slice "+
+			"with the lowercase version: %v", sliceOfString)
+	}
+
+	// test empty slice
+	basicalter.ReplaceInSliceWith([]string{}, strings.ToLower)
+}
+
 func TestReplaceStringsWith(t *testing.T) {
 	sliceOfString := []string{"Foo", "Bar", "Baz"}
 

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -8,6 +8,42 @@ import (
 	"github.com/jeremmfr/go-utils/basiccheck"
 )
 
+func TestUniqueInSlice(t *testing.T) {
+	sliceOfString := []string{"foo", "bar"}
+	if len(basicalter.UniqueInSlice(sliceOfString)) != len(sliceOfString) {
+		t.Errorf("UniqueInSlice returned bad slice with slice without duplicate entry")
+	}
+
+	sliceOfString = append(sliceOfString, "foo")
+	if v := basicalter.UniqueInSlice(sliceOfString); len(v) == len(sliceOfString) {
+		t.Errorf("UniqueInSlice didn't remove duplicate foo in slice: %v", v)
+	}
+
+	// test empty slice
+	_ = len(basicalter.UniqueInSlice([]string{}))
+
+	// test nil slice
+	var nilSlice []string
+	if basicalter.UniqueInSlice(nilSlice) != nil {
+		t.Errorf("UniqueInSlice didn't return nil slice with nil input slice")
+	}
+
+	sliceOfInt := []int{1, 2}
+	if len(basicalter.UniqueInSlice(sliceOfInt)) != len(sliceOfInt) {
+		t.Errorf("UniqueInSlice returned bad slice with slice without duplicate entry")
+	}
+
+	sliceOfInt = append(sliceOfInt, 1)
+	if v := basicalter.UniqueInSlice(sliceOfInt); len(v) == len(sliceOfInt) {
+		t.Errorf("UniqueInSlice didn't remove duplicate 1 in slice: %v", v)
+	}
+
+	// test slice with one element
+	if v := basicalter.UniqueInSlice([]float64{1.2}); len(v) != 1 || v[0] != 1.2 {
+		t.Errorf("UniqueInSlice didn't return the same slice with one element")
+	}
+}
+
 func TestUniqueStrings(t *testing.T) {
 	sliceOfString := []string{"foo", "bar"}
 

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -80,6 +80,25 @@ func TestDelStringInSlice(t *testing.T) {
 	}
 }
 
+func TestFilterInSliceWith(t *testing.T) {
+	sliceOfString := []string{"foo", "baz", "bar", "baz"}
+
+	if v := basicalter.FilterInSliceWith(sliceOfString, func(s string) bool {
+		return strings.HasPrefix(s, "ba")
+	}); len(v) != 3 {
+		t.Errorf("FilterInSliceWith didn't remove foo (without prefix 'ba'): %v", v)
+	} else if !basiccheck.EqualSlice(v, []string{"baz", "bar", "baz"}) {
+		t.Errorf("FilterInSliceWith didn't remove foo (without prefix 'ba'): %v", v)
+	}
+
+	var nilSlice []string
+	if v := basicalter.FilterInSliceWith(nilSlice, func(s string) bool {
+		return true
+	}); v != nil {
+		t.Errorf("FilterInSliceWith didn't return nil slice with nil input slice")
+	}
+}
+
 func TestFilterStringsWith(t *testing.T) {
 	sliceOfString := []string{"foo", "baz", "bar", "baz"}
 

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -124,6 +124,26 @@ func TestFilterStringsWith(t *testing.T) {
 func TestReverseSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "baz", "bar", "World", "Hello"}
 
+	basicalter.ReverseSlice(sliceOfString)
+
+	desiredStringSlice := []string{"Hello", "World", "bar", "baz", "foo"}
+	if !basiccheck.EqualSlice(sliceOfString, desiredStringSlice) {
+		t.Errorf("ReverseSlice didn't reverse slice: %v expected %v", sliceOfString, desiredStringSlice)
+	}
+
+	sliceOfInt64 := []int64{3, 2, 1, 0}
+
+	basicalter.ReverseSlice(sliceOfInt64)
+
+	desiredInt64Slice := []int64{0, 1, 2, 3}
+	if !basiccheck.EqualSlice(sliceOfInt64, desiredInt64Slice) {
+		t.Errorf("ReverseSlice didn't reverse slice: %v expected %v", sliceOfInt64, desiredInt64Slice)
+	}
+}
+
+func TestReverseStrings(t *testing.T) {
+	sliceOfString := []string{"foo", "baz", "bar", "World", "Hello"}
+
 	basicalter.ReverseStrings(sliceOfString)
 
 	desiredSlice := []string{"Hello", "World", "bar", "baz", "foo"}


### PR DESCRIPTION
* add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
* add `DelInSlice` function with generic parameters in `basicalter` package to replace `DelStringInSlice` function which is now deprecated
* add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated
* add `ReverseSlice` function with generic parameters in `basicalter` package to replace `ReverseStrings` function which is now deprecated
* add `ReplaceInSliceWith` function with generic parameters in `basicalter` package to replace `ReplaceStringsWith` function which is now deprecated

