### PR TITLE
remove deprecated functions in basicalter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # changelog
 
+* :warning: **BREAKING CHANGES**: remove deprecated functions in `basicalter`: `UniqueStrings`, `DelStringInSlice`, `FilterStringsWith`, `ReverseStrings`, `ReplaceStringsWith`
+
 ## v0.6.0
 
-* :warning: **BREAKING CHANGES**: remove deprecated functions in basiccheck: `StringInSlice`, `EqualStringSlice`, `IntInSlice`, `Int64InSlice`, `OneOfStringsWith`, `AllStringsWith`
+* :warning: **BREAKING CHANGES**: remove deprecated functions in `basiccheck`: `StringInSlice`, `EqualStringSlice`, `IntInSlice`, `Int64InSlice`, `OneOfStringsWith`, `AllStringsWith`
 * add `UniqueInSlice` function with generic parameters in `basicalter` package to replace `UniqueStrings` function which is now deprecated
 * add `DelInSlice` function with generic parameters in `basicalter` package to replace `DelStringInSlice` function which is now deprecated
 * add `FilterInSliceWith` function with generic parameters in `basicalter` package to replace `FilterStringsWith` function which is now deprecated

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -30,22 +30,6 @@ func UniqueInSlice[T comparable, S ~[]T](list S) S {
 	}
 }
 
-// UniqueStrings remove duplicate string in slice of string.
-//
-// Deprecated: use UniqueInSlice() instead.
-func UniqueStrings(list []string) []string {
-	k := make(map[string]struct{}, len(list))
-	r := []string{}
-	for _, v := range list {
-		if _, ok := k[v]; !ok {
-			k[v] = struct{}{}
-			r = append(r, v)
-		}
-	}
-
-	return r
-}
-
 // DelEmptyStrings remove empty elements in slice of string
 // and return the result with a new slice.
 func DelEmptyStrings(list []string) []string {
@@ -57,15 +41,6 @@ func DelEmptyStrings(list []string) []string {
 func DelInSlice[T comparable, S ~[]T](elem T, list S) S {
 	return FilterInSliceWith(list, func(e T) bool {
 		return e != elem
-	})
-}
-
-// DelStringInSlice remove all occurrence of a string in slice of string.
-//
-// Deprecated: use DelInSlice() instead.
-func DelStringInSlice(str string, list []string) []string {
-	return FilterStringsWith(list, func(s string) bool {
-		return s != str
 	})
 }
 
@@ -86,32 +61,8 @@ func FilterInSliceWith[T any, S ~[]T](list S, filter func(T) bool) S {
 	return r
 }
 
-// FilterStringsWith generate a new slice of string
-// by applying on 'list' a function 'filter' to determine the inclusion of each element.
-//
-// Deprecated: use FilterInSliceWith() instead.
-func FilterStringsWith(list []string, filter func(string) bool) []string {
-	r := make([]string, 0)
-	for _, v := range list {
-		if filter(v) {
-			r = append(r, v)
-		}
-	}
-
-	return r
-}
-
 // ReverseSlice reverse order of a slice last to first, before last to second, etc.
 func ReverseSlice[T any](list []T) {
-	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
-		list[i], list[j] = list[j], list[i]
-	}
-}
-
-// ReverseStrings reverse order of string slice last to first, before last to second, etc.
-//
-// Deprecated: use ReverseSlice() instead.
-func ReverseStrings(list []string) {
 	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
 		list[i], list[j] = list[j], list[i]
 	}
@@ -172,16 +123,6 @@ func (s sortStringsLengthDec) Less(i, j int) bool {
 // ReplaceInSliceWith replace each element of a slice
 // with the result of the function 'replace' passed in arguments.
 func ReplaceInSliceWith[T any](list []T, replace func(T) T) {
-	for i := 0; i < len(list); i++ {
-		list[i] = replace(list[i])
-	}
-}
-
-// ReplaceStringsWith replace each string of a slice
-// with the result of the function 'replace' passed in arguments.
-//
-// Deprecated: use ReplaceInSliceWith() instead.
-func ReplaceStringsWith(list []string, replace func(string) string) {
 	for i := 0; i < len(list); i++ {
 		list[i] = replace(list[i])
 	}

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -44,22 +44,6 @@ func TestUniqueInSlice(t *testing.T) {
 	}
 }
 
-func TestUniqueStrings(t *testing.T) {
-	sliceOfString := []string{"foo", "bar"}
-
-	if len(basicalter.UniqueStrings(sliceOfString)) != len(sliceOfString) {
-		t.Errorf("UniqueStrings returned bad slice with slice without duplicate entry")
-	}
-
-	sliceOfString = append(sliceOfString, "foo")
-
-	if v := basicalter.UniqueStrings(sliceOfString); len(v) == len(sliceOfString) {
-		t.Errorf("UniqueStrings didn't remove duplicate foo in slice: %v", v)
-	}
-	// test empty list
-	_ = len(basicalter.UniqueStrings([]string{}))
-}
-
 func TestDelEmptyStrings(t *testing.T) {
 	sliceOfString := []string{"foo", "", "bar"}
 
@@ -77,16 +61,6 @@ func TestDelInSlice(t *testing.T) {
 		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
 	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
 		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
-	}
-}
-
-func TestDelStringInSlice(t *testing.T) {
-	sliceOfString := []string{"foo", "baz", "bar", "baz"}
-
-	if v := basicalter.DelStringInSlice("baz", sliceOfString); len(v) != 2 {
-		t.Errorf("DelStringInSlice didn't remove 'baz': %v", v)
-	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
-		t.Errorf("DelStringInSlice didn't remove 'baz': %v", v)
 	}
 }
 
@@ -109,18 +83,6 @@ func TestFilterInSliceWith(t *testing.T) {
 	}
 }
 
-func TestFilterStringsWith(t *testing.T) {
-	sliceOfString := []string{"foo", "baz", "bar", "baz"}
-
-	if v := basicalter.FilterStringsWith(sliceOfString, func(s string) bool {
-		return strings.HasPrefix(s, "ba")
-	}); len(v) != 3 {
-		t.Errorf("FilterStringsWith didn't remove foo (without prefix 'ba'): %v", v)
-	} else if !basiccheck.EqualSlice(v, []string{"baz", "bar", "baz"}) {
-		t.Errorf("FilterStringsWith didn't remove foo (without prefix 'ba'): %v", v)
-	}
-}
-
 func TestReverseSlice(t *testing.T) {
 	sliceOfString := []string{"foo", "baz", "bar", "World", "Hello"}
 
@@ -138,17 +100,6 @@ func TestReverseSlice(t *testing.T) {
 	desiredInt64Slice := []int64{0, 1, 2, 3}
 	if !basiccheck.EqualSlice(sliceOfInt64, desiredInt64Slice) {
 		t.Errorf("ReverseSlice didn't reverse slice: %v expected %v", sliceOfInt64, desiredInt64Slice)
-	}
-}
-
-func TestReverseStrings(t *testing.T) {
-	sliceOfString := []string{"foo", "baz", "bar", "World", "Hello"}
-
-	basicalter.ReverseStrings(sliceOfString)
-
-	desiredSlice := []string{"Hello", "World", "bar", "baz", "foo"}
-	if !basiccheck.EqualSlice(sliceOfString, desiredSlice) {
-		t.Errorf("ReverseStrings didn't reverse slice: %v expected %v", sliceOfString, desiredSlice)
 	}
 }
 
@@ -186,18 +137,4 @@ func TestReplaceInSliceWith(t *testing.T) {
 
 	// test empty slice
 	basicalter.ReplaceInSliceWith([]string{}, strings.ToLower)
-}
-
-func TestReplaceStringsWith(t *testing.T) {
-	sliceOfString := []string{"Foo", "Bar", "Baz"}
-
-	basicalter.ReplaceStringsWith(sliceOfString, strings.ToLower)
-
-	if !basiccheck.EqualSlice(sliceOfString, []string{"foo", "bar", "baz"}) {
-		t.Errorf("ReplaceStringsWith didn't replace all strings in slice "+
-			"with the lowercase version: %v", sliceOfString)
-	}
-
-	// test empty slice
-	basicalter.ReplaceStringsWith([]string{}, strings.ToLower)
 }


### PR DESCRIPTION
- `UniqueStrings`
- `DelStringInSlice`
- `FilterStringsWith`
- `ReverseStrings`
- `ReplaceStringsWith`