### PR TITLE
add `CutPrefixInString` and `CutSuffixInString` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* add `CutPrefixInString` and `CutSuffixInString` functions in `basicalter` package (check and trim prefix/suffix on the value of a string pointer)
+
 ## v0.7.0
 
 * :warning: **BREAKING CHANGES**: remove deprecated functions in `basicalter`: `UniqueStrings`, `DelStringInSlice`, `FilterStringsWith`, `ReverseStrings`, `ReplaceStringsWith`

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -79,3 +79,17 @@ func ExampleMergeMaps() {
 	fmt.Printf("%+v", m1)
 	// Output: map[bar:baz foo:baz]
 }
+
+func ExampleCutPrefixInString() {
+	str := "foobar"
+	basicalter.CutPrefixInString(&str, "foo")
+	fmt.Println(str)
+	// Output: bar
+}
+
+func ExampleCutSuffixInString() {
+	str := "foobar"
+	basicalter.CutSuffixInString(&str, "bar")
+	fmt.Println(str)
+	// Output: foo
+}

--- a/basicalter/string.go
+++ b/basicalter/string.go
@@ -1,0 +1,45 @@
+package basicalter
+
+import "strings"
+
+// CutPrefixInString rewrites the value of 's' without the provided
+// leading 'prefix' string and reports whether it found the prefix.
+// If 's' is nil or if its value doesn't start with 'prefix', CutPrefixInString
+// doesn't rewrite the value of 's' and returns false.
+// If 'prefix' is the empty string, CutPrefixInString returns true without rewriting.
+func CutPrefixInString(s *string, prefix string) bool {
+	if s == nil {
+		return false
+	}
+	if len(prefix) == 0 {
+		return true
+	}
+	if !strings.HasPrefix(*s, prefix) {
+		return false
+	}
+	str := *s
+	*s = str[len(prefix):]
+
+	return true
+}
+
+// CutSuffixInString rewrites the value of 's' without the provided
+// ending 'suffix' string and reports whether it found the suffix.
+// If 's' is nil or if its value doesn't end with 'suffix', CutSuffixInString
+// doesn't rewrite the value of 's' and returns false.
+// If 'suffix' is the empty string, CutSuffixInString returns true without rewriting.
+func CutSuffixInString(s *string, suffix string) bool {
+	if s == nil {
+		return false
+	}
+	if len(suffix) == 0 {
+		return true
+	}
+	if !strings.HasSuffix(*s, suffix) {
+		return false
+	}
+	str := *s
+	*s = str[:len(str)-len(suffix)]
+
+	return true
+}

--- a/basicalter/string_test.go
+++ b/basicalter/string_test.go
@@ -1,0 +1,55 @@
+package basicalter_test
+
+import (
+	"testing"
+
+	"github.com/jeremmfr/go-utils/basicalter"
+)
+
+const (
+	foobar = "foobar"
+)
+
+func TestCutPrefixInString(t *testing.T) {
+	if basicalter.CutPrefixInString(nil, "pre") {
+		t.Errorf("CutPrefixInString returns true with nil for the string pointer")
+	}
+	str := foobar
+	if !basicalter.CutPrefixInString(&str, "") {
+		t.Errorf("CutPrefixInString returns false with empty prefix")
+	} else if str != foobar {
+		t.Errorf("CutPrefixInString has rewrite input string with empty prefix: %s", str)
+	}
+	if basicalter.CutPrefixInString(&str, "pre") {
+		t.Errorf("CutPrefixInString returns true with other prefix")
+	} else if str != foobar {
+		t.Errorf("CutPrefixInString has rewrite input string with other prefix: %s", str)
+	}
+	if !basicalter.CutPrefixInString(&str, "foo") {
+		t.Errorf("CutPrefixInString returns false with good prefix")
+	} else if str != "bar" {
+		t.Errorf("CutPrefixInString has rewrite input string with bad string: %s", str)
+	}
+}
+
+func TestCutSuffixInString(t *testing.T) {
+	if basicalter.CutSuffixInString(nil, "pre") {
+		t.Errorf("CutSuffixInString returns true with nil for the string pointer")
+	}
+	str := foobar
+	if !basicalter.CutSuffixInString(&str, "") {
+		t.Errorf("CutSuffixInString returns false with empty suffix")
+	} else if str != foobar {
+		t.Errorf("CutSuffixInString has rewrite input string with empty suffix: %s", str)
+	}
+	if basicalter.CutSuffixInString(&str, "pre") {
+		t.Errorf("CutSuffixInString returns true with other suffix")
+	} else if str != foobar {
+		t.Errorf("CutSuffixInString has rewrite input string with other suffix: %s", str)
+	}
+	if !basicalter.CutSuffixInString(&str, "bar") {
+		t.Errorf("CutSuffixInString returns false with good suffix")
+	} else if str != "foo" {
+		t.Errorf("CutSuffixInString has rewrite input string with bad string: %s", str)
+	}
+}


### PR DESCRIPTION
* add `CutPrefixInString` and `CutSuffixInString` functions in `basicalter` package (check and trim prefix/suffix on the value of a string pointer)