### PR TITLE
basicalter: add DelRuneInStringWith and FilterRuneInStringWith functions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: '1.18'
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -22,7 +22,21 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.19'
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Test
+        run: go test -v ./...
+
+  test-1_20:
+    name: Test 1.20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.51
           args: -c .golangci.yml -v

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: '1.20'
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,9 @@ linters:
 linters-settings:
   govet:
     enable-all: true
+issues:
+  exclude-rules:
+    - path: '(.+)_test\.go'
+      linters:
+        - funlen
+        - goconst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* add `DelRuneInStringWith` and `FilterRuneInStringWith` functions in `basicalter` package (remove specific rune(s) on the value of a string pointer with functions)
+
 ## v0.8.0
 
 * add `CutPrefixInString` and `CutSuffixInString` functions in `basicalter` package (check and trim prefix/suffix on the value of a string pointer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * add `DelRuneInStringWith` and `FilterRuneInStringWith` functions in `basicalter` package (remove specific rune(s) on the value of a string pointer with functions)
 * avoid panic when `find` is nil with function `OneInSliceWith` in `basiccheck` package
 * avoid panic when `valid` is nil with function `AllInSliceWith` in `basiccheck` package
+* avoid panic when `filter` is nil with function `FilterInSliceWith` in `basicalter` package
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * add `DelRuneInStringWith` and `FilterRuneInStringWith` functions in `basicalter` package (remove specific rune(s) on the value of a string pointer with functions)
 * avoid panic when `find` is nil with function `OneInSliceWith` in `basiccheck` package
+* avoid panic when `valid` is nil with function `AllInSliceWith` in `basiccheck` package
 
 ## v0.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
 * add `DelRuneInStringWith` and `FilterRuneInStringWith` functions in `basicalter` package (remove specific rune(s) on the value of a string pointer with functions)
+* avoid panic when `find` is nil with function `OneInSliceWith` in `basiccheck` package
 
 ## v0.8.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
 default: gotest/html
 
-.PHONY: gotest gotest/html
+.PHONY: gotest gotest/html pkgsite pkgsite/install 
 
 gotest:
 	go test -covermode=count -v ./...
 
 gotest/html:
 	go test -v ./... -coverprofile=coverage.out && go tool cover -html=coverage.out
+
+pkgsite: pkgsite/install
+	@echo "open -> http://localhost:8080/$(shell go list -m)"
+	pkgsite
+
+pkgsite/install:
+	go install golang.org/x/pkgsite/cmd/pkgsite@latest

--- a/basicalter/example_test.go
+++ b/basicalter/example_test.go
@@ -3,6 +3,7 @@ package basicalter_test
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/jeremmfr/go-utils/basicalter"
 )
@@ -92,4 +93,18 @@ func ExampleCutSuffixInString() {
 	basicalter.CutSuffixInString(&str, "bar")
 	fmt.Println(str)
 	// Output: foo
+}
+
+func ExampleDelRuneInStringWith() {
+	str := "foo 1 bar"
+	basicalter.DelRuneInStringWith(&str, unicode.IsSpace, unicode.IsDigit)
+	fmt.Println(str)
+	// Output: foobar
+}
+
+func ExampleFilterRuneInStringWith() {
+	str := "foo 1 bar"
+	basicalter.FilterRuneInStringWith(&str, unicode.IsLetter)
+	fmt.Println(str)
+	// Output: foobar
 }

--- a/basicalter/map.go
+++ b/basicalter/map.go
@@ -3,6 +3,7 @@ package basicalter
 // MergeMaps copies all key/value pairs in 'srcs' maps to 'dst' map.
 // Set 'overwrite' to true to allow copy value when the key is already set
 // in 'dst' or previous element of 'srcs'.
+//
 // If 'dst' is nil, MergeMaps is a no-op.
 func MergeMaps[K comparable, V any, M ~map[K]V](dst M, overwrite bool, srcs ...M) {
 	if dst == nil {

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -47,9 +47,16 @@ func DelInSlice[T comparable, S ~[]T](elem T, list S) S {
 // FilterInSliceWith generate a new slice
 // by applying on an input slice 'list' a function 'filter'
 // to determine the inclusion of each element.
+//
+// If 'list' is nil, FilterInSliceWith return nil.
+//
+// If 'filter' is nil, FilterInSliceWith return list.
 func FilterInSliceWith[T any, S ~[]T](list S, filter func(T) bool) S {
 	if list == nil {
 		return nil
+	}
+	if filter == nil {
+		return list
 	}
 	r := make(S, 0, cap(list))
 	for _, v := range list {

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -67,6 +67,10 @@ func TestDelInSlice(t *testing.T) {
 func TestFilterInSliceWith(t *testing.T) {
 	sliceOfString := []string{"foo", "baz", "bar", "baz"}
 
+	if v := basicalter.FilterInSliceWith(sliceOfString, nil); len(v) != len(sliceOfString) {
+		t.Errorf("FilterInSliceWith didn't return same slice with nil filter: %v", v)
+	}
+
 	if v := basicalter.FilterInSliceWith(sliceOfString, func(s string) bool {
 		return strings.HasPrefix(s, "ba")
 	}); len(v) != 3 {

--- a/basicalter/string.go
+++ b/basicalter/string.go
@@ -43,3 +43,36 @@ func CutSuffixInString(s *string, suffix string) bool {
 
 	return true
 }
+
+// DelRuneInStringWith rewrites the value of 's' without the rune(s)
+// that return true with one of the 'filtersOut' functions.
+//
+// If 's' is nil, DelRuneInStringWith is a no-op.
+func DelRuneInStringWith(s *string, filtersOut ...func(rune) bool) {
+	if s == nil {
+		return
+	}
+	for _, f := range filtersOut {
+		if f == nil {
+			continue
+		}
+		FilterRuneInStringWith(s, func(r rune) bool { return !f(r) })
+	}
+}
+
+// FilterRuneInStringWith rewrites the value of 's'
+// with the rune(s) that return true with the function 'filter'.
+//
+// If 's' or 'filter' is nil, FilterRuneInStringWith is a no-op.
+func FilterRuneInStringWith(s *string, filter func(rune) bool) {
+	if s == nil || filter == nil {
+		return
+	}
+	*s = strings.Map(func(r rune) rune {
+		if filter(r) {
+			return r
+		}
+
+		return -1
+	}, *s)
+}

--- a/basicalter/string.go
+++ b/basicalter/string.go
@@ -1,11 +1,15 @@
 package basicalter
 
-import "strings"
+import (
+	"strings"
+)
 
 // CutPrefixInString rewrites the value of 's' without the provided
 // leading 'prefix' string and reports whether it found the prefix.
+//
 // If 's' is nil or if its value doesn't start with 'prefix', CutPrefixInString
 // doesn't rewrite the value of 's' and returns false.
+//
 // If 'prefix' is the empty string, CutPrefixInString returns true without rewriting.
 func CutPrefixInString(s *string, prefix string) bool {
 	if s == nil {
@@ -25,8 +29,10 @@ func CutPrefixInString(s *string, prefix string) bool {
 
 // CutSuffixInString rewrites the value of 's' without the provided
 // ending 'suffix' string and reports whether it found the suffix.
+//
 // If 's' is nil or if its value doesn't end with 'suffix', CutSuffixInString
 // doesn't rewrite the value of 's' and returns false.
+//
 // If 'suffix' is the empty string, CutSuffixInString returns true without rewriting.
 func CutSuffixInString(s *string, suffix string) bool {
 	if s == nil {

--- a/basicalter/string_test.go
+++ b/basicalter/string_test.go
@@ -2,6 +2,7 @@ package basicalter_test
 
 import (
 	"testing"
+	"unicode"
 
 	"github.com/jeremmfr/go-utils/basicalter"
 )
@@ -51,5 +52,55 @@ func TestCutSuffixInString(t *testing.T) {
 		t.Errorf("CutSuffixInString returns false with good suffix")
 	} else if str != "foo" {
 		t.Errorf("CutSuffixInString has rewrite input string with bad string: %s", str)
+	}
+}
+
+func TestDelRuneInStringWith(t *testing.T) {
+	s1 := "bar ! &foo"
+	basicalter.DelRuneInStringWith(nil, unicode.IsDigit)
+	basicalter.DelRuneInStringWith(&s1, nil)
+	basicalter.DelRuneInStringWith(&s1, unicode.IsSpace)
+	if s1 != "bar!&foo" {
+		t.Errorf("DelRuneInStringWith doesn't change the original string with good value: %q", s1)
+	}
+
+	s2 := "bar ! &foo"
+	basicalter.DelRuneInStringWith(&s2, unicode.IsSpace, unicode.IsPunct)
+	if s2 != "barfoo" {
+		t.Errorf("DelRuneInStringWith doesn't change the original string with good value: %q", s2)
+	}
+
+	s3 := "barfoo"
+	basicalter.DelRuneInStringWith(&s3, unicode.IsSpace)
+	if s3 != "barfoo" {
+		t.Errorf("DelRuneInStringWith change the original string with other value: %q", s3)
+	}
+
+	var s4 string
+	basicalter.DelRuneInStringWith(&s4, func(r rune) bool { return !unicode.IsPrint(r) })
+	if s4 != "" {
+		t.Errorf("DelRuneInStringWith change the original empty string with other value: %q", s4)
+	}
+
+	s5 := string('\n')
+	basicalter.DelRuneInStringWith(&s5, func(r rune) bool { return !unicode.IsPrint(r) })
+	if s5 != "" {
+		t.Errorf("DelRuneInStringWith doesn't change the original string with no printable value: %q", s5)
+	}
+}
+
+func TestFilterRuneInStringWith(t *testing.T) {
+	s1 := "foo ! &baz"
+	basicalter.FilterRuneInStringWith(nil, unicode.IsLetter)
+	basicalter.FilterRuneInStringWith(&s1, nil)
+	basicalter.FilterRuneInStringWith(&s1, unicode.IsLetter)
+	if s1 != "foobaz" {
+		t.Errorf("FilterRuneInStringWith doesn't change the original string with good value: %q", s1)
+	}
+
+	s2 := "foobar"
+	basicalter.FilterRuneInStringWith(&s2, unicode.IsLetter)
+	if s2 != "foobar" {
+		t.Errorf("FilterRuneInStringWith change the original string with other value: %q", s2)
 	}
 }

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -23,7 +23,12 @@ func EqualSlice[T comparable](a, b []T) bool {
 
 // OneInSliceWith check if at least one element in a slice
 // returns true with the function 'find' passed in arguments.
+//
+// If 'find' is nil, return false.
 func OneInSliceWith[T any](list []T, find func(T) bool) bool {
+	if find == nil {
+		return false
+	}
 	for _, v := range list {
 		if find(v) {
 			return true

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -40,7 +40,12 @@ func OneInSliceWith[T any](list []T, find func(T) bool) bool {
 
 // AllInSliceWith check if all elements in a slice
 // return true with the function 'valid' passed in arguments.
+//
+// If 'valid' is nil, return true.
 func AllInSliceWith[T any](list []T, valid func(T) bool) bool {
+	if valid == nil {
+		return true
+	}
 	for _, v := range list {
 		if !valid(v) {
 			return false

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -74,6 +74,10 @@ func TestOneInSliceWith(t *testing.T) {
 func TestAllInSliceWith(t *testing.T) {
 	sliceOfString := []string{}
 
+	if !basiccheck.AllInSliceWith(sliceOfString, nil) {
+		t.Errorf("AllInSliceWith return false with nil find")
+	}
+
 	if !basiccheck.AllInSliceWith(sliceOfString, func(s string) bool {
 		return strings.HasPrefix(s, "b")
 	}) {

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -46,6 +46,10 @@ func TestEqualSlice(t *testing.T) {
 func TestOneInSliceWith(t *testing.T) {
 	sliceOfString := []string{}
 
+	if basiccheck.OneInSliceWith(sliceOfString, nil) {
+		t.Errorf("OneInSliceWith return true with nil find")
+	}
+
 	if basiccheck.OneInSliceWith(sliceOfString, func(s string) bool {
 		return strings.HasPrefix(s, "b")
 	}) {


### PR DESCRIPTION
* add `DelRuneInStringWith` and `FilterRuneInStringWith` functions in `basicalter` package (remove specific rune(s) on the value of a string pointer with functions)
* avoid panic when `find` is nil with function `OneInSliceWith` in `basiccheck` package
* avoid panic when `valid` is nil with function `AllInSliceWith` in `basiccheck` package
* avoid panic when `filter` is nil with function `FilterInSliceWith` in `basicalter` package