### PR TITLE
Golang v1.21-22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,48 +1,6 @@
 name: Go Tests
 on: [push, pull_request]
 jobs:
-  test-1_18:
-    name: Test 1.18
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.18
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.18'
-        id: go
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Test
-        run: go test -v ./...
-
-  test-1_19:
-    name: Test 1.19
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.19'
-        id: go
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Test
-        run: go test -v ./...
-
-  test-1_20:
-    name: Test 1.20
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.20
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.20'
-        id: go
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Test
-        run: go test -v ./...
-
   test-1_21:
     name: Test 1.21
     runs-on: ubuntu-latest
@@ -51,6 +9,20 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Test
+        run: go test -v ./...
+
+  test-1_22:
+    name: Test 1.22
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
         id: go
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,12 +8,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
         id: go
       - name: Check out code
         uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.56
           args: -c .golangci.yml -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* golang 1.21 is now the minimum version
+
 ## v0.11.0
 
 * add `SimilarSlice` function in `basiccheck` package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   use [slices.Reverse()](https://pkg.go.dev/slices#Reverse) from the standard [slices](https://pkg.go.dev/slices) library instead
 * :warning: `EqualSlice` function in `basiccheck` package is now deprecated  
   use [slices.Equal()](https://pkg.go.dev/slices#Equal) from the standard [slices](https://pkg.go.dev/slices) library instead
+* :warning: `InSlice` function in `basiccheck` package is now deprecated  
+  use [slices.Contains()](https://pkg.go.dev/slices#Contains) from the standard [slices](https://pkg.go.dev/slices) library instead
 
 ## v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   use [slices.Equal()](https://pkg.go.dev/slices#Equal) from the standard [slices](https://pkg.go.dev/slices) library instead
 * :warning: `InSlice` function in `basiccheck` package is now deprecated  
   use [slices.Contains()](https://pkg.go.dev/slices#Contains) from the standard [slices](https://pkg.go.dev/slices) library instead
+* :warning: `OneInSliceWith` function in `basiccheck` package is now deprecated  
+  use [slices.ContainsFunc()](https://pkg.go.dev/slices#ContainsFunc) from the standard [slices](https://pkg.go.dev/slices) library instead
 
 ## v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # changelog
 
 * golang 1.21 is now the minimum version
+* :warning: `ReverseSlice` function in `basicalter` package is now deprecated  
+  use [slices.Reverse()](https://pkg.go.dev/slices#Reverse) from the standard [slices](https://pkg.go.dev/slices) library instead
 
 ## v0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * golang 1.21 is now the minimum version
 * :warning: `ReverseSlice` function in `basicalter` package is now deprecated  
   use [slices.Reverse()](https://pkg.go.dev/slices#Reverse) from the standard [slices](https://pkg.go.dev/slices) library instead
+* :warning: `EqualSlice` function in `basiccheck` package is now deprecated  
+  use [slices.Equal()](https://pkg.go.dev/slices#Equal) from the standard [slices](https://pkg.go.dev/slices) library instead
 
 ## v0.11.0
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ import (
 )
 
 func main() {
-     sliceOfString := []string{"foo", "bar"}
+     s1 := []string{"foo", "bar"}
+     s2 := []string{"bar", "foo"}
 
-     if basiccheck.InSlice("bar", sliceOfString) {
-          fmt.Printf("bar found in %v", sliceOfString)
-          // Output: bar found in [foo bar]
+     if basiccheck.SimilarSlice(s1, s2) {
+          fmt.Printf("%v =~ %v", s1, s2)
+          // Output: [foo bar] =~ [bar foo]
      } else {
-          fmt.Printf("bar not found in %v", sliceOfString)
+          fmt.Printf("%v != %v", s1, s2)
      }
 }
 ```

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -1,6 +1,8 @@
 package basicalter
 
-import "sort"
+import (
+	"sort"
+)
 
 // UniqueInSlice remove duplicate elements in slice
 // and return the result with a new slice.

--- a/basicalter/slice.go
+++ b/basicalter/slice.go
@@ -71,6 +71,8 @@ func FilterInSliceWith[T any, S ~[]T](list S, filter func(T) bool) S {
 }
 
 // ReverseSlice reverse order of a slice last to first, before last to second, etc.
+//
+// Deprecated: use slices.Reverse() from the standard 'slices' library instead.
 func ReverseSlice[T any](list []T) {
 	for i, j := 0, len(list)-1; i < j; i, j = i+1, j-1 {
 		list[i], list[j] = list[j], list[i]

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -1,11 +1,11 @@
 package basicalter_test
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/jeremmfr/go-utils/basicalter"
-	"github.com/jeremmfr/go-utils/basiccheck"
 )
 
 func TestUniqueInSlice(t *testing.T) {
@@ -49,7 +49,7 @@ func TestDelEmptyStrings(t *testing.T) {
 
 	if v := basicalter.DelEmptyStrings(sliceOfString); len(v) != 2 {
 		t.Errorf("DelEmptyStrings didn't remove empty string: %v", v)
-	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
+	} else if !slices.Equal(v, []string{"foo", "bar"}) {
 		t.Errorf("DelEmptyStrings didn't remove empty string: %v", v)
 	}
 }
@@ -59,7 +59,7 @@ func TestDelInSlice(t *testing.T) {
 
 	if v := basicalter.DelInSlice("baz", sliceOfString); len(v) != 2 {
 		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
-	} else if !basiccheck.EqualSlice(v, []string{"foo", "bar"}) {
+	} else if !slices.Equal(v, []string{"foo", "bar"}) {
 		t.Errorf("DelInSlice didn't remove 'baz': %v", v)
 	}
 }
@@ -75,7 +75,7 @@ func TestFilterInSliceWith(t *testing.T) {
 		return strings.HasPrefix(s, "ba")
 	}); len(v) != 3 {
 		t.Errorf("FilterInSliceWith didn't remove foo (without prefix 'ba'): %v", v)
-	} else if !basiccheck.EqualSlice(v, []string{"baz", "bar", "baz"}) {
+	} else if !slices.Equal(v, []string{"baz", "bar", "baz"}) {
 		t.Errorf("FilterInSliceWith didn't remove foo (without prefix 'ba'): %v", v)
 	}
 
@@ -93,7 +93,7 @@ func TestReverseSlice(t *testing.T) {
 	basicalter.ReverseSlice(sliceOfString)
 
 	desiredStringSlice := []string{"Hello", "World", "bar", "baz", "foo"}
-	if !basiccheck.EqualSlice(sliceOfString, desiredStringSlice) {
+	if !slices.Equal(sliceOfString, desiredStringSlice) {
 		t.Errorf("ReverseSlice didn't reverse slice: %v expected %v", sliceOfString, desiredStringSlice)
 	}
 
@@ -102,7 +102,7 @@ func TestReverseSlice(t *testing.T) {
 	basicalter.ReverseSlice(sliceOfInt64)
 
 	desiredInt64Slice := []int64{0, 1, 2, 3}
-	if !basiccheck.EqualSlice(sliceOfInt64, desiredInt64Slice) {
+	if !slices.Equal(sliceOfInt64, desiredInt64Slice) {
 		t.Errorf("ReverseSlice didn't reverse slice: %v expected %v", sliceOfInt64, desiredInt64Slice)
 	}
 }
@@ -113,7 +113,7 @@ func TestSortStringsByLengthInc(t *testing.T) {
 	basicalter.SortStringsByLengthInc(s)
 
 	desiredSlice := []string{"Go", "Grin", "Alpha", "Bravo", "Delta", "Gopher"}
-	if !basiccheck.EqualSlice(s, desiredSlice) {
+	if !slices.Equal(s, desiredSlice) {
 		t.Errorf("SortStringsByLength didn't sort slice with smaller first and lexicographic order")
 	}
 }
@@ -124,7 +124,7 @@ func TestSortStringsByLengthDec(t *testing.T) {
 	basicalter.SortStringsByLengthDec(s)
 
 	desiredSlice := []string{"Gopher", "Alpha", "Bravo", "Delta", "Grin", "Go"}
-	if !basiccheck.EqualSlice(s, desiredSlice) {
+	if !slices.Equal(s, desiredSlice) {
 		t.Errorf("SortStringsByLength didn't sort slice with smaller last and lexicographic order")
 	}
 }
@@ -134,7 +134,7 @@ func TestReplaceInSliceWith(t *testing.T) {
 
 	basicalter.ReplaceInSliceWith(sliceOfString, strings.ToLower)
 
-	if !basiccheck.EqualSlice(sliceOfString, []string{"foo", "bar", "baz"}) {
+	if !slices.Equal(sliceOfString, []string{"foo", "bar", "baz"}) {
 		t.Errorf("ReplaceInSliceWith didn't replace all strings in slice "+
 			"with the lowercase version: %v", sliceOfString)
 	}

--- a/basicalter/slice_test.go
+++ b/basicalter/slice_test.go
@@ -80,7 +80,7 @@ func TestFilterInSliceWith(t *testing.T) {
 	}
 
 	var nilSlice []string
-	if v := basicalter.FilterInSliceWith(nilSlice, func(s string) bool {
+	if v := basicalter.FilterInSliceWith(nilSlice, func(_ string) bool {
 		return true
 	}); v != nil {
 		t.Errorf("FilterInSliceWith didn't return nil slice with nil input slice")

--- a/basiccheck/example_test.go
+++ b/basiccheck/example_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 func Example() {
-	input := []string{"foo", "bar"}
-	if basiccheck.InSlice("bar", input) {
-		fmt.Printf("bar found in %v", input)
-		// Output: bar found in [foo bar]
+	input1 := []string{"foo", "bar"}
+	input2 := []string{"bar", "foo"}
+	if basiccheck.SimilarSlice(input1, input2) {
+		fmt.Printf("%v =~ %v", input1, input2)
+		// Output: [foo bar] =~ [bar foo]
 	} else {
-		fmt.Printf("bar not found in %v", input)
+		fmt.Printf("%v != %v", input1, input2)
 	}
 }
 

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -8,6 +8,8 @@ func InSlice[T comparable](elem T, list []T) bool {
 }
 
 // EqualSlice check if two slice is Equal: same length, same element in same order.
+//
+// Deprecated: use slices.Equal() from the standard 'slices' library instead.
 func EqualSlice[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -46,6 +46,8 @@ func SimilarSlice[T comparable](a, b []T) bool {
 // returns true with the function 'find' passed in arguments.
 //
 // If 'find' is nil, return false.
+//
+// Deprecated: use slices.ContainsFunc() from the standard 'slices' library instead.
 func OneInSliceWith[T any](list []T, find func(T) bool) bool {
 	if find == nil {
 		return false

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -1,6 +1,10 @@
 package basiccheck
 
+import "slices"
+
 // InSlice check if an element is present in a slice.
+//
+// Deprecated: use slices.Contains() from the standard 'slices' library instead.
 func InSlice[T comparable](elem T, list []T) bool {
 	return OneInSliceWith(list, func(v T) bool {
 		return v == elem
@@ -30,7 +34,7 @@ func SimilarSlice[T comparable](a, b []T) bool {
 		return false
 	}
 	for _, v := range a {
-		if !InSlice(v, b) {
+		if !slices.Contains(b, v) {
 			return false
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jeremmfr/go-utils
 
-go 1.18
+go 1.21


### PR DESCRIPTION
* golang 1.21 is now the minimum version
* :warning: `ReverseSlice` function in `basicalter` package is now deprecated  
  use [slices.Reverse()](https://pkg.go.dev/slices#Reverse) from the standard [slices](https://pkg.go.dev/slices) library instead
* :warning: `EqualSlice` function in `basiccheck` package is now deprecated  
  use [slices.Equal()](https://pkg.go.dev/slices#Equal) from the standard [slices](https://pkg.go.dev/slices) library instead
* :warning: `InSlice` function in `basiccheck` package is now deprecated  
  use [slices.Contains()](https://pkg.go.dev/slices#Contains) from the standard [slices](https://pkg.go.dev/slices) library instead
* :warning: `OneInSliceWith` function in `basiccheck` package is now deprecated  
  use [slices.ContainsFunc()](https://pkg.go.dev/slices#ContainsFunc) from the standard [slices](https://pkg.go.dev/slices) library instead