### PR TITLE
Slices intersect & similar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # changelog
 
 * add `SliceIntersect` function in `basicnew` package
+* fix unexpected result for `SimilarSlice` in `basiccheck` when there are elements of arguments present multiple times, but not in the same way in each argument
 
 ## v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # changelog
 
+* add `SliceIntersect` function in `basicnew` package
+
 ## v0.12.0
 
 * golang 1.21 is now the minimum version

--- a/basiccheck/slice.go
+++ b/basiccheck/slice.go
@@ -1,6 +1,8 @@
 package basiccheck
 
-import "slices"
+import (
+	"maps"
+)
 
 // InSlice check if an element is present in a slice.
 //
@@ -29,17 +31,26 @@ func EqualSlice[T comparable](a, b []T) bool {
 
 // SimilarSlice check if two slice is Similar:
 // same length, same element (not necessarily in same order).
+//
+// Elements that appear multiple times must appear same times between the two slices.
 func SimilarSlice[T comparable](a, b []T) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	aElems := make(map[T]int, len(a))
 	for _, v := range a {
-		if !slices.Contains(b, v) {
-			return false
-		}
+		aElems[v]++
 	}
 
-	return true
+	bElems := make(map[T]int, len(a))
+	for _, v := range b {
+		if _, ok := aElems[v]; !ok {
+			return false
+		}
+		bElems[v]++
+	}
+
+	return maps.Equal(aElems, bElems)
 }
 
 // OneInSliceWith check if at least one element in a slice

--- a/basiccheck/slice_test.go
+++ b/basiccheck/slice_test.go
@@ -44,34 +44,65 @@ func TestEqualSlice(t *testing.T) {
 }
 
 func TestSimilarSlice(t *testing.T) {
-	sliceA := []string{"foo", "bar", "baz"}
-	sliceB := []string{"foo", "baz", "bar"}
-	sliceC := []string{"foo", "bar"}
+	t.Parallel()
 
-	if !basiccheck.SimilarSlice(sliceA, sliceB) {
-		t.Errorf("SimilarSlice didn't find similar slice %v, %v", sliceA, sliceB)
-	}
-	if basiccheck.SimilarSlice(sliceA, sliceC) {
-		t.Errorf("SimilarSlice found similar slice %v, %v", sliceA, sliceC)
+	type testCase struct {
+		a            []string
+		b            []string
+		expectResult bool
 	}
 
-	sliceC = append(sliceC, "baz")
-	if !basiccheck.SimilarSlice(sliceA, sliceC) {
-		t.Errorf("SimilarSlice didn't find similar slice %v, %v", sliceA, sliceC)
+	tests := map[string]testCase{
+		"nil|nil": {
+			a:            nil,
+			b:            nil,
+			expectResult: true,
+		},
+		"foo_bar_baz": {
+			a:            []string{"foo", "bar", "baz"},
+			b:            []string{"foo", "baz", "bar"},
+			expectResult: true,
+		},
+		"foo_bar+baz": {
+			a:            []string{"foo", "bar", "baz"},
+			b:            []string{"foo", "bar"},
+			expectResult: false,
+		},
+		"foo_bar_baz_2": {
+			a:            []string{"foo", "bar", "baz"},
+			b:            []string{"foo", "bar", "baz"},
+			expectResult: true,
+		},
+		"bar_baz+fo": {
+			a:            []string{"foo", "bar", "baz"},
+			b:            []string{"fo", "bar", "baz"},
+			expectResult: false,
+		},
+		"foo_bar_baz|nil": {
+			a:            []string{"foo", "bar", "baz"},
+			b:            nil,
+			expectResult: false,
+		},
+		"foo*2_bar_baz": {
+			a:            []string{"foo", "bar", "baz", "foo"},
+			b:            []string{"foo", "bar", "baz", "foo"},
+			expectResult: true,
+		},
+		"foo*2_bar*2_baz*2": {
+			a:            []string{"foo", "bar", "baz", "foo", "bar"},
+			b:            []string{"foo", "bar", "baz", "foo", "baz"},
+			expectResult: false,
+		},
 	}
 
-	sliceC[0] = "fo"
-	if basiccheck.SimilarSlice(sliceA, sliceC) {
-		t.Errorf("SimilarSlice found similar slice %v, %v", sliceA, sliceC)
-	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	sliceC = nil
-	if basiccheck.SimilarSlice(sliceA, sliceC) {
-		t.Errorf("SimilarSlice found similar slice %v, %v", sliceA, sliceC)
-	}
-	sliceA = nil
-	if !basiccheck.SimilarSlice(sliceA, sliceC) {
-		t.Errorf("SimilarSlice didn't find similar slice %v, %v", sliceA, sliceC)
+			if b := basiccheck.SimilarSlice(test.a, test.b); b != test.expectResult {
+				t.Errorf("got unexpected result: want %v, got %v", test.expectResult, b)
+			}
+		})
 	}
 }
 

--- a/basicnew/example_test.go
+++ b/basicnew/example_test.go
@@ -41,3 +41,13 @@ func ExampleMapValues() {
 	fmt.Println(values)
 	// Output: [baz baz]
 }
+
+func ExampleSliceIntersect() {
+	result := basicnew.SliceIntersect(
+		[]string{"foo", "bar"},
+		[]string{"baz", "foobar", "bar", "bar"},
+	)
+
+	fmt.Println(result)
+	// Output: [bar]
+}

--- a/basicnew/slice.go
+++ b/basicnew/slice.go
@@ -1,0 +1,28 @@
+package basicnew
+
+// SliceIntersect generate a new slice with
+// elements present in both slices.
+//
+// If an element is present multiple times in one of the argument lists,
+// it will be present only once in the result.
+func SliceIntersect[T comparable](a, b []T) []T {
+	aElems := make(map[T]bool, len(a))
+	for _, v := range a {
+		aElems[v] = false
+	}
+
+	resultCap := len(a)
+	if v := len(b); v < resultCap {
+		resultCap = v
+	}
+	result := make([]T, 0, resultCap)
+
+	for _, v := range b {
+		if set, ok := aElems[v]; ok && !set {
+			result = append(result, v)
+			aElems[v] = true
+		}
+	}
+
+	return result
+}

--- a/basicnew/slice_test.go
+++ b/basicnew/slice_test.go
@@ -1,0 +1,62 @@
+package basicnew_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/jeremmfr/go-utils/basicnew"
+)
+
+func TestSliceIntersect(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		a            []string
+		b            []string
+		expectResult []string
+	}
+
+	tests := map[string]testCase{
+		"nil": {
+			a:            nil,
+			b:            nil,
+			expectResult: []string{},
+		},
+		"with_0_common": {
+			a:            []string{"a", "b"},
+			b:            []string{"d", "c"},
+			expectResult: []string{},
+		},
+		"with_1_common": {
+			a:            []string{"a", "b"},
+			b:            []string{"b", "c"},
+			expectResult: []string{"b"},
+		},
+		"with_1_common_multiple": {
+			a:            []string{"a", "b", "b"},
+			b:            []string{"b", "c"},
+			expectResult: []string{"b"},
+		},
+		"with_1_common_multiple_b": {
+			a:            []string{"a", "b", "b"},
+			b:            []string{"b", "c", "b"},
+			expectResult: []string{"b"},
+		},
+		"with_2_commons": {
+			a:            []string{"a", "b", "zz"},
+			b:            []string{"b", "c", "zz"},
+			expectResult: []string{"b", "zz"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result := basicnew.SliceIntersect(test.a, test.b)
+			if !slices.Equal(result, test.expectResult) {
+				t.Errorf("got unexpected result: want %v, got %v", test.expectResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* add `SliceIntersect` function in `basicnew` package
* fix unexpected result for `SimilarSlice` in `basiccheck` when there are elements of arguments present multiple times, but not in the same way in each argument

